### PR TITLE
Added a GOOGLE_MAPS_DEFAULT_LANGUAGE constant

### DIFF
--- a/django_google_maps/widgets.py
+++ b/django_google_maps/widgets.py
@@ -13,7 +13,7 @@ class GoogleMapsAddressWidget(widgets.TextInput):
         }
         js = (
             'https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js',
-            'https://maps.google.com/maps/api/js?key={}&libraries=places'.format(
-                settings.GOOGLE_MAPS_API_KEY),
+            'https://maps.google.com/maps/api/js?key={}&libraries=places&language={}'.format(
+                settings.GOOGLE_MAPS_API_KEY, settings.GOOGLE_MAPS_DEFAULT_LANGUAGE),
             settings.STATIC_URL + 'django_google_maps/js/google-maps-admin.js',
         )


### PR DESCRIPTION
This constant can be used to set the default language of the google map widget displayed.

I think it can be useful.

In my case, I'm working with an english client, but work in France, so the google maps API sets the Google Maps iframe to french language (based on my location).

I would like to be able to add items to the database that are in English, so I need to set the Google Maps widget language to English.

Hope this helps !

To use it, you simply have to set the GOOGLE_MAPS_DEFAULT_LANGUAGE in your settings.py file (list of languages: https://developers.google.com/maps/faq#languagesupport)